### PR TITLE
Remove /users/ from robots.txt

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,5 +1,4 @@
 User-agent: *
 Disallow: /themes/
-Disallow: /users/
 
 Sitemap: /sitemap.xml


### PR DESCRIPTION
Since it's already disallowed by `.htaccess`, there's no reason at all to include it in `robots.txt`. This PR fixes that.
